### PR TITLE
Feat: Implemented empty vs only_typed distinction

### DIFF
--- a/autofill-observer-demo/script.js
+++ b/autofill-observer-demo/script.js
@@ -16,15 +16,16 @@
 
 // Possible values for autofill statuses
 const AUTOFILLED = 'autofilled';
-const NEVER_AUTOFILLED = 'never-autofilled';
 const AUTOFILLED_THEN_MODIFIED = 'autofilled-then-modified';
+const EMPTY = 'empty';
+const ONLY_TYPED = 'only-typed';
 
 // Global variable storing autofill statuses for each field
 const autofillStatuses = {};
 // Example: {
 //     "name": "autofilled",
-//     "street-address": "never-autofilled",
-//     "country": "autofilled-then-modified"
+//     "street-address": "autofilled-then-modified",
+//     "country": "only-typed"
 // }
 
 // Update autofill status
@@ -34,11 +35,11 @@ function initializeChangeObserver(formElement) {
   );
   // Intialize autofill status for all fields
   allFieldsAsArray.forEach((fieldElement) => {
-    autofillStatuses[fieldElement.id] = NEVER_AUTOFILLED;
+    autofillStatuses[fieldElement.id] = EMPTY;
   });
   // Add event listener to all fields to update autofill status
   allFieldsAsArray.forEach((fieldElement) => {
-    fieldElement.addEventListener('change', function (event) {
+    fieldElement.addEventListener('change', () => {
       updateAutofillStatus(formElement, fieldElement);
     });
   });
@@ -49,25 +50,48 @@ function getAllAutofilledFields(formElement) {
   return formElement.querySelectorAll(':autofill');
 }
 
-// Check if the passed element is in the list of autofilled fields
+// Check if the element is in the list of autofilled fields
 function checkIsAutofilled(allAutofilledFields, fieldElement) {
   return Array.from(allAutofilledFields).includes(fieldElement);
 }
 
+// Check if the value of the element is empty
+function checkIsEmpty(fieldElement) {
+  const value = fieldElement.value.trim();
+  // value is a string, even for a type = number
+  const isEmpty = value === '';
+  return isEmpty;
+}
+
 function updateAutofillStatus(formElement, fieldElement) {
+  const isEmpty = checkIsEmpty(fieldElement);
   const allAutofilledFields = getAllAutofilledFields(formElement);
   const isAutofilled = checkIsAutofilled(allAutofilledFields, fieldElement);
   const previousAutofillStatus = autofillStatuses[fieldElement.id];
-  if (isAutofilled) {
-    autofillStatuses[fieldElement.id] = AUTOFILLED;
+  if (isEmpty) {
+    if (isAutofilled) {
+      // NOTE: Emptied by autofill
+      autofillStatuses[fieldElement.id] = AUTOFILLED;
+    } else {
+      autofillStatuses[fieldElement.id] = EMPTY;
+      // NOTE: if (previousAutofillStatus === AUTOFILLED), the field was just emptied manually
+    }
   } else {
-    if (previousAutofillStatus === NEVER_AUTOFILLED) {
-      autofillStatuses[fieldElement.id] = NEVER_AUTOFILLED;
-    } else if (
-      previousAutofillStatus === AUTOFILLED ||
-      previousAutofillStatus === AUTOFILLED_THEN_MODIFIED
-    ) {
-      autofillStatuses[fieldElement.id] = AUTOFILLED_THEN_MODIFIED;
+    if (isAutofilled) {
+      autofillStatuses[fieldElement.id] = AUTOFILLED;
+    } else {
+      if (
+        previousAutofillStatus === ONLY_TYPED ||
+        previousAutofillStatus === EMPTY
+      ) {
+        // NOTE: `only_typed` is only used for fields where autofilled was never used. A field where autofilled was used will be `autofilled_then_fixed`, even if the user has completely retyped the whole value
+        autofillStatuses[fieldElement.id] = ONLY_TYPED;
+      } else if (
+        previousAutofillStatus === AUTOFILLED ||
+        previousAutofillStatus === AUTOFILLED_THEN_MODIFIED
+      ) {
+        autofillStatuses[fieldElement.id] = AUTOFILLED_THEN_MODIFIED;
+      }
     }
   }
 }
@@ -77,9 +101,10 @@ function updateAutofillStatus(formElement, fieldElement) {
 function formatAutofillStatusesAsHtml(autofillStatuses) {
   let outputAsHtml = '';
   const autofillStatusFormattedAsHtml = {
-    [AUTOFILLED]: `<span class="positive">✅ Autofilled</span>`,
-    [AUTOFILLED_THEN_MODIFIED]: `<span class="negative">🖊️ Autofilled then manually modified</span>`,
-    [NEVER_AUTOFILLED]: `<span class="neutral">⚫️ Never autofilled</span>`,
+    [AUTOFILLED]: `<span class="autofilled">✅ Autofilled</span>`,
+    [AUTOFILLED_THEN_MODIFIED]: `<span class="autofilled-then-modified">🖊️ Autofilled then manually modified</span>`,
+    [ONLY_TYPED]: `<span class="only-typed">🖊️ Only typed</span>`,
+    [EMPTY]: `<span class="empty">⚫️ Empty</span>`,
   };
   Object.entries(autofillStatuses).forEach(([elId, autofillStatus]) => {
     const output = `<div class="output-wrapper"><div class="element-id">${elId}</div><div>${autofillStatusFormattedAsHtml[autofillStatus]}</div></div>`;

--- a/autofill-observer-demo/script.js
+++ b/autofill-observer-demo/script.js
@@ -76,13 +76,8 @@ function updateAutofillStatus(formElement, fieldElement) {
   const isAutofilled = checkIsAutofilled(allAutofilledFields, fieldElement);
   const previousAutofillStatus = autofillStatuses[fieldElement.id];
   if (isEmpty) {
-    if (isAutofilled) {
-      // NOTE: Emptied by autofill
-      autofillStatuses[fieldElement.id] = AUTOFILLED;
-    } else {
-      autofillStatuses[fieldElement.id] = EMPTY;
-      // NOTE: if (previousAutofillStatus === AUTOFILLED), the field has just been emptied manually
-    }
+    autofillStatuses[fieldElement.id] = EMPTY;
+    // NOTE: if (previousAutofillStatus === AUTOFILLED), the field has just been emptied manually. Autofill can't empty fields.
   } else {
     if (isAutofilled) {
       autofillStatuses[fieldElement.id] = AUTOFILLED;

--- a/autofill-observer-demo/script.js
+++ b/autofill-observer-demo/script.js
@@ -15,9 +15,9 @@
 // ----------------------------- AUTOFILL LOGIC ----------------------------- //
 
 // Possible values for autofill statuses
+const EMPTY = 'empty';
 const AUTOFILLED = 'autofilled';
 const AUTOFILLED_THEN_MODIFIED = 'autofilled-then-modified';
-const EMPTY = 'empty';
 const ONLY_MANUAL = 'only-manual';
 
 // Global variable storing autofill statuses for each field

--- a/autofill-observer-demo/script.js
+++ b/autofill-observer-demo/script.js
@@ -28,16 +28,22 @@ const autofillStatuses = {};
 //     "country": "only-manual"
 // }
 
-// Update autofill status
-function initializeChangeObserver(formElement) {
-  const allFieldsAsArray = Array.from(
-    formElement.querySelectorAll('input, select')
-  );
-  // Intialize autofill status for all fields
+// Collect all field elements for a given form
+function getAllFieldsAsArray(formElement) {
+  return Array.from(formElement.querySelectorAll('input, select'));
+}
+
+// Initialize autofill status for all fields
+function initializeAutofillStatuses(formElement) {
+  const allFieldsAsArray = getAllFieldsAsArray(formElement);
   allFieldsAsArray.forEach((fieldElement) => {
     autofillStatuses[fieldElement.id] = EMPTY;
   });
-  // Add event listener to all fields to update autofill status
+}
+
+// Add event listener to all fields to update autofill status
+function initializeChangeObserver(formElement) {
+  const allFieldsAsArray = getAllFieldsAsArray(formElement);
   allFieldsAsArray.forEach((fieldElement) => {
     fieldElement.addEventListener('change', () => {
       updateAutofillStatus(formElement, fieldElement);
@@ -58,11 +64,12 @@ function checkIsAutofilled(allAutofilledFields, fieldElement) {
 // Check if the value of the element is empty
 function checkIsEmpty(fieldElement) {
   const value = fieldElement.value.trim();
-  // value is a string, even for a type = number
+  // value is a string, even for a type = number field
   const isEmpty = value === '';
   return isEmpty;
 }
 
+// Update autofill status
 function updateAutofillStatus(formElement, fieldElement) {
   const isEmpty = checkIsEmpty(fieldElement);
   const allAutofilledFields = getAllAutofilledFields(formElement);
@@ -74,7 +81,7 @@ function updateAutofillStatus(formElement, fieldElement) {
       autofillStatuses[fieldElement.id] = AUTOFILLED;
     } else {
       autofillStatuses[fieldElement.id] = EMPTY;
-      // NOTE: if (previousAutofillStatus === AUTOFILLED), the field was just emptied manually
+      // NOTE: if (previousAutofillStatus === AUTOFILLED), the field has just been emptied manually
     }
   } else {
     if (isAutofilled) {
@@ -123,6 +130,7 @@ function submitForm(e) {
 
 // ------------------------- MAIN ---------------------- //
 
+initializeAutofillStatuses(document.getElementById('form'));
 initializeChangeObserver(document.getElementById('form'));
 
 window.submitForm = submitForm;

--- a/autofill-observer-demo/script.js
+++ b/autofill-observer-demo/script.js
@@ -18,14 +18,14 @@
 const AUTOFILLED = 'autofilled';
 const AUTOFILLED_THEN_MODIFIED = 'autofilled-then-modified';
 const EMPTY = 'empty';
-const ONLY_TYPED = 'only-typed';
+const ONLY_MANUAL = 'only-manual';
 
 // Global variable storing autofill statuses for each field
 const autofillStatuses = {};
 // Example: {
 //     "name": "autofilled",
 //     "street-address": "autofilled-then-modified",
-//     "country": "only-typed"
+//     "country": "only-manual"
 // }
 
 // Update autofill status
@@ -81,11 +81,11 @@ function updateAutofillStatus(formElement, fieldElement) {
       autofillStatuses[fieldElement.id] = AUTOFILLED;
     } else {
       if (
-        previousAutofillStatus === ONLY_TYPED ||
+        previousAutofillStatus === ONLY_MANUAL ||
         previousAutofillStatus === EMPTY
       ) {
-        // NOTE: `only_typed` is only used for fields where autofilled was never used. A field where autofilled was used will be `autofilled_then_fixed`, even if the user has completely retyped the whole value
-        autofillStatuses[fieldElement.id] = ONLY_TYPED;
+        // NOTE: ONLY_MANUAL is only used for fields where autofilled was *never* used. A field where autofilled was used will be AUTOFILLED_THEN_MODIFIED, even if the user has completely retyped the whole value
+        autofillStatuses[fieldElement.id] = ONLY_MANUAL;
       } else if (
         previousAutofillStatus === AUTOFILLED ||
         previousAutofillStatus === AUTOFILLED_THEN_MODIFIED
@@ -103,7 +103,7 @@ function formatAutofillStatusesAsHtml(autofillStatuses) {
   const autofillStatusFormattedAsHtml = {
     [AUTOFILLED]: `<span class="autofilled">✅ Autofilled</span>`,
     [AUTOFILLED_THEN_MODIFIED]: `<span class="autofilled-then-modified">🖊️ Autofilled then manually modified</span>`,
-    [ONLY_TYPED]: `<span class="only-typed">🖊️ Only typed</span>`,
+    [ONLY_MANUAL]: `<span class="only-manual">🖊️ Filled only manually</span>`,
     [EMPTY]: `<span class="empty">⚫️ Empty</span>`,
   };
   Object.entries(autofillStatuses).forEach(([elId, autofillStatus]) => {

--- a/autofill-observer-demo/style.css
+++ b/autofill-observer-demo/style.css
@@ -25,7 +25,7 @@ body {
 
 main {
   margin: 0 auto;
-  max-width: 26rem;
+  max-width: 27rem;
 }
 
 .demo-metadata {
@@ -142,14 +142,18 @@ button[type='submit'] {
   }
 }
 
-.positive {
+.autofilled {
   color: green;
 }
 
-.negative {
+.autofilled-then-modified {
+  color: blue;
+}
+
+.only-typed {
   color: red;
 }
 
-.neutral {
-  color: inherit;
+.empty {
+  color: rgb(56, 56, 56);
 }

--- a/autofill-observer-demo/style.css
+++ b/autofill-observer-demo/style.css
@@ -150,7 +150,7 @@ button[type='submit'] {
   color: blue;
 }
 
-.only-typed {
+.only-manual {
   color: red;
 }
 


### PR DESCRIPTION
Implemented 4 different autofill statuses:

- `EMPTY`: The user leaves the field empty.
- `AUTOFILLED`: The user fills the field using autofill only.
- `AUTOFILLED_THEN_MODIFIED`: The user first fills the field using autofill, and then manually edits the autofilled value. For example, the user autofills their address and contact details, but manually enters a different phone number.
- `ONLY_MANUAL`: The user fills the field completely manually.